### PR TITLE
The `reflect-metadata` package should be a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,16 +16,17 @@
   "repository": "https://github.com/bitrinjani/castable",
   "author": "bitrinjani <bitrinjani@gmail.com>",
   "license": "MIT",
-  "dependencies": {
-    "reflect-metadata": "^0.1.10"
+  "peerDependencies": {
+    "reflect-metadata": ">=0.1.10"
   },
   "devDependencies": {
     "@types/jest": "^21.1.4",
     "@types/node": "^8.0.46",
     "jest": "^22.0.3",
+    "coveralls": "^3.0.0",
+    "reflect-metadata": ">=0.1.10",
     "ts-jest": "^22.0.0",
-    "typescript": "^2.5.3",
-    "coveralls": "^3.0.0"
+    "typescript": "^2.5.3"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
I have encountered issues when multiple dependencies of a project depend on the `reflect-metadata` package. When this occurs I have seen `tsc` fail to transpile the project source. This has, in my experience, been avoidable by listing `reflect-metadata` in `peerDependencies` instead of `dependencies` and allowing the project itself to install one version of the `reflect-metadata` package.